### PR TITLE
feat: add C/C++, Rust, Go support and clean up configs 

### DIFF
--- a/lua/autocmds.lua
+++ b/lua/autocmds.lua
@@ -20,40 +20,13 @@ vim.api.nvim_create_autocmd({ "BufLeave", "FocusLost", "InsertEnter", "WinLeave"
   end,
 })
 
--- local function darken_color(hex_color, percentage)
---   if not hex_color or hex_color == "NONE" then
---     return "#1a1a1a"
---   end
---
---   hex_color = hex_color:gsub("#", "")
---
---   local r = tonumber(hex_color:sub(1, 2), 16)
---   local g = tonumber(hex_color:sub(3, 4), 16)
---   local b = tonumber(hex_color:sub(5, 6), 16)
---
---   local factor = (100 - percentage) / 100
---   r = math.floor(r * factor)
---   g = math.floor(g * factor)
---   b = math.floor(b * factor)
---
---   return string.format("#%02x%02x%02x", r, g, b)
--- end
-
 vim.api.nvim_create_autocmd("ColorScheme", {
   pattern = "*",
   callback = function()
     local normal_hl = vim.api.nvim_get_hl(0, { name = "Normal" })
     local bg_color = normal_hl.bg
 
-    -- if type(bg_color) == "number" then
-    --   bg_color = string.format("#%06x", bg_color)
-    -- end
-
-    -- local darker_bg = darken_color(bg_color, 20)
-
     vim.api.nvim_set_hl(0, "DapStoppedLine", { bg = "#303300" })
-    -- vim.api.nvim_set_hl(0, "NeoTreeNormal", { bg = bg_color })
-    -- vim.api.nvim_set_hl(0, "NeoTreeNormalNC", { bg = bg_color })
     vim.api.nvim_set_hl(0, "WinSeparator", { bg = bg_color, fg = bg_color })
     vim.api.nvim_set_hl(0, "EndOfBuffer", { fg = bg_color })
   end,

--- a/lua/keymaps.lua
+++ b/lua/keymaps.lua
@@ -5,9 +5,6 @@ local map = vim.keymap.set
 -- Neotree
 map("n", "<C-n>", "<cmd>Neotree toggle<CR>", { desc = "Neotree toggle window" })
 
--- Comment
-map("n", "gcc", "gcc", { desc = "Toggle Comment", remap = true })
-
 map("n", "<leader>e", function()
   vim.diagnostic.open_float { focusable = true }
 end, { desc = "Expand an Error into a float" })
@@ -82,21 +79,12 @@ map("n", "<S-F11>", function()
 end, { desc = "Step out of the current function" })
 
 -- Visual mode mappings
-map("v", "gc", "gc", { desc = "Toggle comment", remap = true })
 map("v", "<leader>fm", function()
   require("conform").format { lsp_fallback = true, async = false, timeout_ms = 1000 }
 end, { desc = "Range format the current visual selection" })
 
 -- Insert mode mappings
 map("i", "<S-Tab>", "<C-d>", { desc = "Move one indentation level back" })
-
-map("n", "<leader>tt", function()
-  require("neotest").watch.toggle(vim.fn.expand "%")
-end, { desc = "Toggle watch mode" })
-
-map("n", "<leader>ta", function()
-  require("neotest").watch.toggle(vim.fn.getcwd())
-end, { desc = "Toggle watch all tests" })
 
 -- Neotest keymaps
 map("n", "<leader>tt", function()
@@ -114,3 +102,11 @@ end, { desc = "Run tests in current file" })
 map("n", "<leader>ta", function()
   require("neotest").run.run(vim.fn.getcwd())
 end, { desc = "Run all tests" })
+
+map("n", "<leader>tw", function()
+  require("neotest").watch.toggle(vim.fn.expand "%")
+end, { desc = "Toggle watch mode for current file" })
+
+map("n", "<leader>tW", function()
+  require("neotest").watch.toggle(vim.fn.getcwd())
+end, { desc = "Toggle watch all tests" })

--- a/lua/plugins/colorscheme.lua
+++ b/lua/plugins/colorscheme.lua
@@ -10,7 +10,7 @@ return {
     branch = "v2",
     dependencies = { "rktjmp/lush.nvim" },
     config = function()
-      vim.cmd [[colorscheme arctic]]
+      vim.cmd [[colorscheme tokyonight]]
     end,
   },
 }

--- a/lua/plugins/comment.lua
+++ b/lua/plugins/comment.lua
@@ -1,6 +1,0 @@
-return {
-  "numToStr/Comment.nvim",
-  config = function()
-    require("Comment").setup {}
-  end,
-}

--- a/lua/plugins/debugger.lua
+++ b/lua/plugins/debugger.lua
@@ -13,7 +13,7 @@ return {
       },
       windows = {
         terminal = {
-          hide = { "delve", "netcoredbg" },
+          hide = { "delve", "netcoredbg", "codelldb" },
         },
       },
     }
@@ -44,7 +44,7 @@ return {
     -- Golang
     local function getMainGoFilePath()
       local main_path = vim.fn.getcwd() .. "/main.go"
-      local dir_entry = vim.loop.fs_stat(main_path)
+      local dir_entry = vim.uv.fs_stat(main_path)
       if dir_entry and dir_entry.type == "file" then
         return main_path
       else
@@ -96,6 +96,134 @@ return {
             to = "/app",
           },
         },
+      },
+    }
+
+    -- C/C++
+    dap.adapters.codelldb = {
+      type = "server",
+      port = "${port}",
+      executable = {
+        command = vim.fn.stdpath "data" .. "/mason/bin/codelldb",
+        args = { "--port", "${port}" },
+      },
+    }
+
+    local function build_c_cpp()
+      local cwd = vim.fn.getcwd()
+
+      if vim.fn.filereadable(cwd .. "/Makefile") == 1 then
+        print "Building with make..."
+        local result = vim.fn.system("make -C " .. cwd)
+        if vim.v.shell_error ~= 0 then
+          vim.notify("Build failed!\n" .. result, vim.log.levels.ERROR)
+          return nil
+        end
+        print "Build successful!"
+        return vim.fn.input("Path to executable: ", cwd .. "/", "file")
+      end
+
+      if vim.fn.filereadable(cwd .. "/CMakeLists.txt") == 1 then
+        print "Building with cmake..."
+        if vim.fn.isdirectory(cwd .. "/build") == 0 then
+          vim.fn.system("cmake -S " .. cwd .. " -B " .. cwd .. "/build -DCMAKE_BUILD_TYPE=Debug")
+        end
+        local result = vim.fn.system("cmake --build " .. cwd .. "/build")
+        if vim.v.shell_error ~= 0 then
+          vim.notify("Build failed!\n" .. result, vim.log.levels.ERROR)
+          return nil
+        end
+        print "Build successful!"
+        return vim.fn.input("Path to executable: ", cwd .. "/build/", "file")
+      end
+
+      local file, compiler
+      if vim.fn.filereadable(cwd .. "/main.cpp") == 1 then
+        file = cwd .. "/main.cpp"
+        compiler = "g++"
+      elseif vim.fn.filereadable(cwd .. "/main.c") == 1 then
+        file = cwd .. "/main.c"
+        compiler = "gcc"
+      else
+        vim.notify("main.c or main.cpp not found", vim.log.levels.ERROR)
+        return nil
+      end
+
+      local output = cwd .. "/" .. "main"
+
+      print("Building with " .. compiler .. "...")
+      local result = vim.fn.system(compiler .. " -g -o " .. output .. " " .. file)
+      if vim.v.shell_error ~= 0 then
+        vim.notify("Build failed!\n" .. result, vim.log.levels.ERROR)
+        return nil
+      end
+
+      print "Build successful!"
+      return output
+    end
+
+    dap.configurations.c = {
+      {
+        type = "codelldb",
+        name = "Debug",
+        request = "launch",
+        program = build_c_cpp,
+        cwd = "${workspaceFolder}",
+        stopOnEntry = false,
+      },
+    }
+
+    dap.configurations.cpp = dap.configurations.c
+
+    -- Rust
+    local function build_rust()
+      local cwd = vim.fn.getcwd()
+      local main_path = cwd .. "/src/main.rs"
+      local dir_entry = vim.uv.fs_stat(main_path)
+
+      if not dir_entry or dir_entry.type ~= "file" then
+        return vim.fn.input("Path to executable: ", cwd .. "/", "file")
+      end
+
+      print "Building project with cargo..."
+      local result = vim.fn.system("cargo build 2>&1")
+      if vim.v.shell_error ~= 0 then
+        vim.notify("Build failed!\n" .. result, vim.log.levels.ERROR)
+        return nil
+      end
+
+      print "Build successful!"
+
+      local project_name = vim.fn.fnamemodify(cwd, ":t")
+      return cwd .. "/target/debug/" .. project_name
+    end
+
+    dap.configurations.rust = {
+      {
+        type = "codelldb",
+        name = "Debug",
+        request = "launch",
+        program = build_rust,
+        cwd = "${workspaceFolder}",
+        stopOnEntry = false,
+      },
+      {
+        type = "codelldb",
+        name = "Debug test",
+        request = "launch",
+        program = function()
+          print "Building tests with cargo..."
+          local result = vim.fn.system("cargo test --no-run 2>&1")
+          if vim.v.shell_error ~= 0 then
+            vim.notify("Build failed!\n" .. result, vim.log.levels.ERROR)
+            return nil
+          end
+
+          print "Build successful!"
+          return vim.fn.input("Path to test executable: ", vim.fn.getcwd() .. "/target/debug/deps/", "file")
+        end,
+        cwd = "${workspaceFolder}",
+        stopOnEntry = false,
       },
     }
 

--- a/lua/plugins/formatter.lua
+++ b/lua/plugins/formatter.lua
@@ -18,11 +18,17 @@ return {
         yaml = { "prettier" },
         graphql = { "prettier" },
         markdown = { "prettier" },
-        svelte = { "prettier --plugin prettier-plugin-svelte" },
-        cs = { "csharpier --print-width 120" },
+        svelte = { "prettier" },
+        cs = { "csharpier" },
         php = { "phpcbf" },
         proto = { "buf" },
-        python = {"pylsp"}
+        python = { "black" },
+        rust = { "rustfmt" },
+      },
+      format_on_save = {
+        lsp_fallback = true,
+        async = false,
+        timeout_ms = 1000,
       },
     }
   end,

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -1,6 +1,6 @@
 local lazypath = vim.fn.stdpath "data" .. "/lazy/lazy.nvim"
 
-if not vim.loop.fs_stat(lazypath) then
+if not vim.uv.fs_stat(lazypath) then
   vim.fn.system {
     "git",
     "clone",

--- a/lua/plugins/lsp.lua
+++ b/lua/plugins/lsp.lua
@@ -62,18 +62,8 @@ return {
       },
     }
 
-    local function on_attach(client, _)
-      if client.supports_method "textDocument/semanticTokens" then
-        client.server_capabilities.semanticTokensProvider = nil
-      end
-      -- if client.supports_method "textDocument/inlayHint" then
-      --   vim.lsp.inlay_hint.enable(true, { bufnr = bufnr })
-      -- end
-    end
-
     vim.lsp.config("*", {
       capabilities = capabilities,
-      on_attach = on_attach,
     })
 
     local servers = {
@@ -209,7 +199,6 @@ return {
         filetypes = { "html", "css", "scss", "javascript", "javascriptreact", "typescript", "typescriptreact", "svelte", "vue" },
         root_dir = function(bufnr, on_dir)
           local root_files = {
-            -- Generic
             "tailwind.config.js",
             "tailwind.config.cjs",
             "tailwind.config.mjs",
@@ -218,13 +207,11 @@ return {
             "postcss.config.cjs",
             "postcss.config.mjs",
             "postcss.config.ts",
-            -- Django
             "theme/static_src/tailwind.config.js",
             "theme/static_src/tailwind.config.cjs",
             "theme/static_src/tailwind.config.mjs",
             "theme/static_src/tailwind.config.ts",
             "theme/static_src/postcss.config.js",
-            -- Fallback for tailwind v4, where tailwind.config.* is not required anymore
             ".git",
           }
           local fname = vim.api.nvim_buf_get_name(bufnr)
@@ -244,11 +231,6 @@ return {
           provideFormatter = true,
         },
       },
-
-      -- pbls = {
-      --   cmd = { "pbls" },
-      --   filetypes = { "proto" },
-      -- },
 
       roslyn = {},
 
@@ -271,19 +253,54 @@ return {
         },
       },
 
-      cmake = {
-        cmd = { "cmake-language-server" },
-        filetypes = { "cmake" },
-        init_options = {
-          buildDirectory = "build",
+      -- cmake = {
+      --   cmd = { "cmake-language-server" },
+      --   filetypes = { "cmake" },
+      --   init_options = {
+      --     buildDirectory = "build",
+      --   },
+      -- },
+
+      rust_analyzer = {
+        cmd = { "rust-analyzer" },
+        filetypes = { "rust" },
+        settings = {
+          ["rust-analyzer"] = {
+            checkOnSave = {
+              command = "clippy",
+            },
+            cargo = {
+              allFeatures = true,
+            },
+            procMacro = {
+              enable = true,
+            },
+            inlayHints = {
+              lifetimeElisionHints = {
+                enable = "always",
+              },
+            },
+          },
         },
       },
 
-      -- angularls = {
-      --   cmd = { "ngserver", "--stdio", "--tsProbeLocations", "", "--ngProbeLocations", "" },
-      --
-      --   filetypes = { "typescript", "html", "typescriptreact", "typescript.tsx", "component.html" },
-      -- },
+      clangd = {
+        cmd = {
+          "clangd",
+          "--background-index",
+          "--clang-tidy",
+          "--header-insertion=iwyu",
+          "--completion-style=detailed",
+          "--function-arg-placeholders",
+          "--fallback-style=llvm",
+        },
+        filetypes = { "c", "cpp", "objc", "objcpp", "cuda", "proto" },
+        init_options = {
+          usePlaceholders = true,
+          completeUnimported = true,
+          clangdFileStatus = true,
+        },
+      },
     }
 
     require("mason-lspconfig").setup {
@@ -298,6 +315,7 @@ return {
       "goimports",
       "shfmt",
       "prettier",
+      "codelldb",
     })
 
     require("mason-tool-installer").setup { ensure_installed = ensure_installed }

--- a/lua/plugins/lualine.lua
+++ b/lua/plugins/lualine.lua
@@ -2,6 +2,20 @@ return {
   "nvim-lualine/lualine.nvim",
   dependencies = { "nvim-tree/nvim-web-devicons" },
   config = function()
-    require("lualine").setup()
+    require("lualine").setup {
+      options = {
+        globalstatus = true,
+        component_separators = { left = "", right = "" },
+        section_separators = { left = "", right = "" },
+      },
+      sections = {
+        lualine_a = { "mode" },
+        lualine_b = { "branch", "diff" },
+        lualine_c = { { "filename", path = 1 } },
+        lualine_x = { "diagnostics", "filetype" },
+        lualine_y = { "progress" },
+        lualine_z = { "location" },
+      },
+    }
   end,
 }

--- a/lua/plugins/neo-tree.lua
+++ b/lua/plugins/neo-tree.lua
@@ -67,7 +67,5 @@ return {
         },
       },
     }
-
-    vim.cmd [[Neotree reveal]]
   end,
 }

--- a/lua/plugins/nvim-treesitter.lua
+++ b/lua/plugins/nvim-treesitter.lua
@@ -11,19 +11,35 @@ return {
   config = function()
     require("nvim-dap-repl-highlights").setup()
     require("nvim-treesitter.configs").setup {
-      ensure_installed = { "lua", "vim", "vimdoc", "typescript", "javascript", "html", "css", "dap_repl" },
+      ensure_installed = {
+        "lua",
+        "vim",
+        "vimdoc",
+        "typescript",
+        "javascript",
+        "html",
+        "css",
+        "dap_repl",
+        "go",
+        "gomod",
+        "gosum",
+        "sql",
+        "json",
+        "yaml",
+        "dockerfile",
+      },
       sync_install = false,
       auto_install = true,
       highlight = {
         enable = true,
         disable = function(_, buf)
           local max_filesize = 200 * 1024 -- 200 KB
-          local ok, stats = pcall(vim.loop.fs_stat, vim.api.nvim_buf_get_name(buf))
+          local ok, stats = pcall(vim.uv.fs_stat, vim.api.nvim_buf_get_name(buf))
           if ok and stats and stats.size > max_filesize then
             return true
           end
         end,
-        additional_vim_regex_highlighting = true,
+        additional_vim_regex_highlighting = false,
         use_languagetree = true,
       },
     }

--- a/lua/plugins/tests.lua
+++ b/lua/plugins/tests.lua
@@ -6,12 +6,14 @@ return {
     "antoinemadec/FixCursorHold.nvim",
     "nvim-treesitter/nvim-treesitter",
     "nsidorenco/neotest-vstest",
+    "fredrikaverpil/neotest-golang",
   },
   config = function()
     require("neotest").setup {
       log_level = 1,
       adapters = {
         require "neotest-vstest",
+        require "neotest-golang",
       },
       icons = {
         expanded = "",

--- a/lua/settings.lua
+++ b/lua/settings.lua
@@ -1,15 +1,5 @@
 local o = vim.opt
 local g = vim.g
-local vf = vim.fn
-
-vim.diagnostic.config {
-  virtual_text = { current_line = true },
-}
-
-vf.sign_define("DiagnosticSignError", { text = "", texthl = "DiagnosticSignError" })
-vf.sign_define("DiagnosticSignWarn", { text = "", texthl = "DiagnosticSignWarn" })
-vf.sign_define("DiagnosticSignInfo", { text = "", texthl = "DiagnosticSignInfo" })
-vf.sign_define("DiagnosticSignHint", { text = "󰌵", texthl = "DiagnosticSignHint" })
 
 -- Sets the leader key to the space bar.
 g.mapleader = " "


### PR DESCRIPTION
  ## Summary                                                                                                                                                                        
  - Add C/C++ and Rust debugging support via codelldb DAP adapter with automatic build (make, cmake, gcc, cargo)                                                                    
  - Add rust_analyzer and clangd LSP servers
  - Add neotest-golang test adapter for Go test support
  - Add rustfmt and black formatters, enable format_on_save
  - Remove Comment.nvim plugin (using native Neovim commenting)
  - Reorganize neotest keymaps with distinct watch bindings (`<leader>tw` / `<leader>tW`)
  - Improve lualine, neo-tree, and treesitter configurations
  - Clean up commented-out code and migrate vim.loop to vim.uv
  - Change default colorscheme to tokyonight