### PR TITLE
fix: enable treesitter parser auto-install

### DIFF
--- a/lua/plugins/tree-sitter-manager.lua
+++ b/lua/plugins/tree-sitter-manager.lua
@@ -2,6 +2,34 @@ return {
   "romus204/tree-sitter-manager.nvim",
   dependencies = {},
   config = function()
-    require("tree-sitter-manager").setup()
+    require("tree-sitter-manager").setup {
+      auto_install = true,
+      ensure_installed = {
+        "bash",
+        "c",
+        "c_sharp",
+        "css",
+        "dockerfile",
+        "eex",
+        "elixir",
+        "go",
+        "gomod",
+        "gosum",
+        "heex",
+        "html",
+        "javascript",
+        "json",
+        "lua",
+        "markdown",
+        "markdown_inline",
+        "query",
+        "sql",
+        "tsx",
+        "typescript",
+        "vim",
+        "vimdoc",
+        "yaml",
+      },
+    }
   end,
 }


### PR DESCRIPTION
## Problema

Ao abrir um arquivo `.html`, nenhum parser era baixado e o highlight do treesitter não ativava.

A causa é o `setup()` do `tree-sitter-manager` estar sem argumentos. Os defaults do plugin (`lua/tree-sitter-manager/config.lua`) trazem:

- `auto_install = false`, então o autocmd de `FileType` que instala parser faltando (`init.lua:58`) nunca era registrado
- `ensure_installed = {}`, então nada era instalado no startup

O `parser_dir` do plugin (`~/.local/share/nvim/site/parser`) ficava vazio. Os `.so` presentes em `lazy/nvim-treesitter/parser/` são resíduo do antigo `nvim-treesitter` no branch `master` e não são enxergados pelo plugin novo.

## Mudança

Liga `auto_install` e popula `ensure_installed` com as linguagens já em uso.

## Observação

O plugin exige o `tree-sitter` CLI instalado no sistema para compilar os parsers. No Arch: `sudo pacman -S tree-sitter-cli`. Sem ele, a instalação dos parsers falha.

🤖 Generated with [Claude Code](https://claude.com/claude-code)